### PR TITLE
feat: Add scm_device resource and data sources for device-to-folder management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/paloaltonetworks/terraform-provider-scm
 
 go 1.24.0
 
-//replace github.com/paloaltonetworks/scm-go => ../scm-go
+replace github.com/paloaltonetworks/scm-go => ../scm-go
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.23.0

--- a/internal/models/config_setup/model_devices.go
+++ b/internal/models/config_setup/model_devices.go
@@ -1,0 +1,250 @@
+package models
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// Package: config_setup
+// This file contains models for the Devices resource (moving firewalls into folders)
+
+// DevicesTf represents the Terraform model for Devices
+type DevicesTf struct {
+	Tfid            types.String          `tfsdk:"tfid"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	Name            basetypes.StringValue `tfsdk:"name"`
+	Folder          basetypes.StringValue `tfsdk:"folder"`
+	Description     basetypes.StringValue `tfsdk:"description"`
+	DisplayName     basetypes.StringValue `tfsdk:"display_name"`
+	Labels          basetypes.ListValue   `tfsdk:"labels"`
+	Snippets        basetypes.ListValue   `tfsdk:"snippets"`
+	Hostname        basetypes.StringValue `tfsdk:"hostname"`
+	IpAddress       basetypes.StringValue `tfsdk:"ip_address"`
+	IpV6Address     basetypes.StringValue `tfsdk:"ipv6_address"`
+	MacAddress      basetypes.StringValue `tfsdk:"mac_address"`
+	Family          basetypes.StringValue `tfsdk:"family"`
+	Model           basetypes.StringValue `tfsdk:"model"`
+	SoftwareVersion basetypes.StringValue `tfsdk:"software_version"`
+	IsConnected     basetypes.BoolValue   `tfsdk:"is_connected"`
+}
+
+// AttrTypes defines the attribute types for the DevicesTf model.
+func (o DevicesTf) AttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"tfid":             basetypes.StringType{},
+		"id":               basetypes.StringType{},
+		"name":             basetypes.StringType{},
+		"folder":           basetypes.StringType{},
+		"description":      basetypes.StringType{},
+		"display_name":     basetypes.StringType{},
+		"labels":           basetypes.ListType{ElemType: basetypes.StringType{}},
+		"snippets":         basetypes.ListType{ElemType: basetypes.StringType{}},
+		"hostname":         basetypes.StringType{},
+		"ip_address":       basetypes.StringType{},
+		"ipv6_address":     basetypes.StringType{},
+		"mac_address":      basetypes.StringType{},
+		"family":           basetypes.StringType{},
+		"model":            basetypes.StringType{},
+		"software_version": basetypes.StringType{},
+		"is_connected":     basetypes.BoolType{},
+	}
+}
+
+// AttrType returns the attribute type for a list of DevicesTf objects.
+func (o DevicesTf) AttrType() attr.Type {
+	return basetypes.ObjectType{
+		AttrTypes: o.AttrTypes(),
+	}
+}
+
+// DevicesResourceSchema defines the schema for the Devices resource.
+// This resource manages device-to-folder assignment, labels, and snippets.
+// The device itself is not created or deleted by Terraform — it already exists in SCM.
+var DevicesResourceSchema = schema.Schema{
+	MarkdownDescription: "Manages a device in Strata Cloud Manager. Use this resource to move firewalls into folders, update labels, and manage snippets.",
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			MarkdownDescription: "The UUID of the device",
+			Required:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"folder": schema.StringAttribute{
+			MarkdownDescription: "The folder containing the device. Set this to move a device into a folder.",
+			Required:            true,
+		},
+		"description": schema.StringAttribute{
+			MarkdownDescription: "The description of the device",
+			Optional:            true,
+			Computed:            true,
+		},
+		"display_name": schema.StringAttribute{
+			MarkdownDescription: "The display name of the device",
+			Optional:            true,
+			Computed:            true,
+		},
+		"labels": schema.ListAttribute{
+			ElementType:         types.StringType,
+			MarkdownDescription: "Labels assigned to the device",
+			Optional:            true,
+			Computed:            true,
+		},
+		"snippets": schema.ListAttribute{
+			ElementType:         types.StringType,
+			MarkdownDescription: "Snippets associated with the device",
+			Optional:            true,
+			Computed:            true,
+		},
+		"name": schema.StringAttribute{
+			MarkdownDescription: "The serial number / name of the device",
+			Computed:            true,
+		},
+		"hostname": schema.StringAttribute{
+			MarkdownDescription: "The hostname of the device",
+			Computed:            true,
+		},
+		"ip_address": schema.StringAttribute{
+			MarkdownDescription: "The IPv4 address of the device",
+			Computed:            true,
+		},
+		"ipv6_address": schema.StringAttribute{
+			MarkdownDescription: "The IPv6 address of the device",
+			Computed:            true,
+		},
+		"mac_address": schema.StringAttribute{
+			MarkdownDescription: "The MAC address of the device",
+			Computed:            true,
+		},
+		"family": schema.StringAttribute{
+			MarkdownDescription: "The product family of the device",
+			Computed:            true,
+		},
+		"model": schema.StringAttribute{
+			MarkdownDescription: "The model of the device",
+			Computed:            true,
+		},
+		"software_version": schema.StringAttribute{
+			MarkdownDescription: "The software version running on the device",
+			Computed:            true,
+		},
+		"is_connected": schema.BoolAttribute{
+			MarkdownDescription: "Whether the device is currently connected",
+			Computed:            true,
+		},
+		"tfid": schema.StringAttribute{
+			MarkdownDescription: "The Terraform ID.",
+			Computed:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+	},
+}
+
+// DevicesDataSourceSchema defines the schema for the Devices data source.
+var DevicesDataSourceSchema = dsschema.Schema{
+	MarkdownDescription: "Retrieves information about a device in Strata Cloud Manager.",
+	Attributes: map[string]dsschema.Attribute{
+		"id": dsschema.StringAttribute{
+			MarkdownDescription: "The UUID of the device",
+			Required:            true,
+		},
+		"name": dsschema.StringAttribute{
+			MarkdownDescription: "The serial number / name of the device",
+			Computed:            true,
+		},
+		"folder": dsschema.StringAttribute{
+			MarkdownDescription: "The folder containing the device",
+			Computed:            true,
+		},
+		"description": dsschema.StringAttribute{
+			MarkdownDescription: "The description of the device",
+			Computed:            true,
+		},
+		"display_name": dsschema.StringAttribute{
+			MarkdownDescription: "The display name of the device",
+			Computed:            true,
+		},
+		"labels": dsschema.ListAttribute{
+			ElementType:         types.StringType,
+			MarkdownDescription: "Labels assigned to the device",
+			Computed:            true,
+		},
+		"snippets": dsschema.ListAttribute{
+			ElementType:         types.StringType,
+			MarkdownDescription: "Snippets associated with the device",
+			Computed:            true,
+		},
+		"hostname": dsschema.StringAttribute{
+			MarkdownDescription: "The hostname of the device",
+			Computed:            true,
+		},
+		"ip_address": dsschema.StringAttribute{
+			MarkdownDescription: "The IPv4 address of the device",
+			Computed:            true,
+		},
+		"ipv6_address": dsschema.StringAttribute{
+			MarkdownDescription: "The IPv6 address of the device",
+			Computed:            true,
+		},
+		"mac_address": dsschema.StringAttribute{
+			MarkdownDescription: "The MAC address of the device",
+			Computed:            true,
+		},
+		"family": dsschema.StringAttribute{
+			MarkdownDescription: "The product family of the device",
+			Computed:            true,
+		},
+		"model": dsschema.StringAttribute{
+			MarkdownDescription: "The model of the device",
+			Computed:            true,
+		},
+		"software_version": dsschema.StringAttribute{
+			MarkdownDescription: "The software version running on the device",
+			Computed:            true,
+		},
+		"is_connected": dsschema.BoolAttribute{
+			MarkdownDescription: "Whether the device is currently connected",
+			Computed:            true,
+		},
+		"tfid": dsschema.StringAttribute{
+			MarkdownDescription: "The Terraform ID.",
+			Computed:            true,
+		},
+	},
+}
+
+// DevicesListModel represents the data model for a list data source.
+type DevicesListModel struct {
+	Tfid   types.String `tfsdk:"tfid"`
+	Data   []DevicesTf  `tfsdk:"data"`
+	Limit  types.Int64  `tfsdk:"limit"`
+	Offset types.Int64  `tfsdk:"offset"`
+	Total  types.Int64  `tfsdk:"total"`
+	Folder types.String `tfsdk:"folder"`
+}
+
+// DevicesListDataSourceSchema defines the schema for a list data source.
+var DevicesListDataSourceSchema = dsschema.Schema{
+	MarkdownDescription: "Retrieves a listing of devices in Strata Cloud Manager.",
+	Attributes: map[string]dsschema.Attribute{
+		"tfid": dsschema.StringAttribute{Description: "The Terraform ID.", Computed: true},
+		"data": dsschema.ListNestedAttribute{
+			Description: "The list of devices.",
+			Computed:    true,
+			NestedObject: dsschema.NestedAttributeObject{
+				Attributes: DevicesDataSourceSchema.Attributes,
+			},
+		},
+		"limit":  dsschema.Int64Attribute{Description: "The max number of items to return. Default: 200.", Optional: true},
+		"offset": dsschema.Int64Attribute{Description: "The offset of the first item to return.", Optional: true},
+		"total":  dsschema.Int64Attribute{Description: "The total number of items.", Computed: true},
+		"folder": dsschema.StringAttribute{Description: "Filter devices by folder.", Optional: true},
+	},
+}

--- a/internal/models/config_setup/model_devices_test.go
+++ b/internal/models/config_setup/model_devices_test.go
@@ -1,0 +1,187 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// Test_DevicesResourceSchema_RequiredAttributes verifies that the resource schema
+// has the correct required vs optional vs computed attributes.
+func Test_DevicesResourceSchema_RequiredAttributes(t *testing.T) {
+	s := DevicesResourceSchema
+
+	requiredFields := []string{"id", "folder"}
+	for _, field := range requiredFields {
+		attr, ok := s.Attributes[field]
+		if !ok {
+			t.Errorf("Resource schema missing required attribute: %s", field)
+			continue
+		}
+		if sa, ok := attr.(schema.StringAttribute); ok {
+			if !sa.Required {
+				t.Errorf("Resource attribute %q should be Required", field)
+			}
+		}
+	}
+}
+
+func Test_DevicesResourceSchema_OptionalAttributes(t *testing.T) {
+	s := DevicesResourceSchema
+
+	optionalFields := []string{"description", "display_name", "labels", "snippets"}
+	for _, field := range optionalFields {
+		attr, ok := s.Attributes[field]
+		if !ok {
+			t.Errorf("Resource schema missing optional attribute: %s", field)
+			continue
+		}
+		switch a := attr.(type) {
+		case schema.StringAttribute:
+			if !a.Optional {
+				t.Errorf("Resource attribute %q should be Optional", field)
+			}
+			if !a.Computed {
+				t.Errorf("Resource attribute %q should also be Computed", field)
+			}
+		case schema.ListAttribute:
+			if !a.Optional {
+				t.Errorf("Resource attribute %q should be Optional", field)
+			}
+			if !a.Computed {
+				t.Errorf("Resource attribute %q should also be Computed", field)
+			}
+		}
+	}
+}
+
+func Test_DevicesResourceSchema_ComputedOnlyAttributes(t *testing.T) {
+	s := DevicesResourceSchema
+
+	computedOnly := []string{
+		"name", "hostname", "ip_address", "ipv6_address",
+		"mac_address", "family", "model", "software_version",
+		"is_connected", "tfid",
+	}
+	for _, field := range computedOnly {
+		attr, ok := s.Attributes[field]
+		if !ok {
+			t.Errorf("Resource schema missing computed attribute: %s", field)
+			continue
+		}
+		switch a := attr.(type) {
+		case schema.StringAttribute:
+			if !a.Computed {
+				t.Errorf("Resource attribute %q should be Computed", field)
+			}
+			if a.Required {
+				t.Errorf("Resource attribute %q should NOT be Required", field)
+			}
+		case schema.BoolAttribute:
+			if !a.Computed {
+				t.Errorf("Resource attribute %q should be Computed", field)
+			}
+		}
+	}
+}
+
+func Test_DevicesResourceSchema_IdRequiresReplace(t *testing.T) {
+	s := DevicesResourceSchema
+
+	attr, ok := s.Attributes["id"]
+	if !ok {
+		t.Fatal("Resource schema missing 'id' attribute")
+	}
+	sa, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatal("'id' attribute is not a StringAttribute")
+	}
+	if len(sa.PlanModifiers) == 0 {
+		t.Error("'id' attribute should have plan modifiers (RequiresReplace)")
+	}
+}
+
+// Test_DevicesDataSourceSchema_Attributes verifies data source schema.
+func Test_DevicesDataSourceSchema_Attributes(t *testing.T) {
+	s := DevicesDataSourceSchema
+
+	// ID is required for data source lookup
+	idAttr, ok := s.Attributes["id"]
+	if !ok {
+		t.Fatal("Data source schema missing 'id' attribute")
+	}
+	if !idAttr.IsRequired() {
+		t.Error("Data source 'id' should be Required")
+	}
+
+	// All other fields should be computed
+	computedFields := []string{
+		"name", "folder", "description", "display_name",
+		"labels", "snippets", "hostname", "ip_address",
+		"ipv6_address", "mac_address", "family", "model",
+		"software_version", "is_connected", "tfid",
+	}
+	for _, field := range computedFields {
+		attr, ok := s.Attributes[field]
+		if !ok {
+			t.Errorf("Data source schema missing attribute: %s", field)
+			continue
+		}
+		if !attr.IsComputed() {
+			t.Errorf("Data source attribute %q should be Computed", field)
+		}
+	}
+}
+
+// Test_DevicesListDataSourceSchema_Attributes verifies the list data source schema.
+func Test_DevicesListDataSourceSchema_Attributes(t *testing.T) {
+	s := DevicesListDataSourceSchema
+
+	// Check optional filter attributes
+	optionalFields := []string{"limit", "offset", "folder"}
+	for _, field := range optionalFields {
+		attr, ok := s.Attributes[field]
+		if !ok {
+			t.Errorf("List data source schema missing attribute: %s", field)
+			continue
+		}
+		if !attr.IsOptional() {
+			t.Errorf("List data source attribute %q should be Optional", field)
+		}
+	}
+
+	// Check computed attributes
+	computedFields := []string{"tfid", "total", "data"}
+	for _, field := range computedFields {
+		attr, ok := s.Attributes[field]
+		if !ok {
+			t.Errorf("List data source schema missing attribute: %s", field)
+			continue
+		}
+		if !attr.IsComputed() {
+			t.Errorf("List data source attribute %q should be Computed", field)
+		}
+	}
+}
+
+// Test_DevicesTf_AttrTypes verifies that AttrTypes returns all expected keys.
+func Test_DevicesTf_AttrTypes(t *testing.T) {
+	d := DevicesTf{}
+	attrTypes := d.AttrTypes()
+
+	expectedKeys := []string{
+		"tfid", "id", "name", "folder", "description", "display_name",
+		"labels", "snippets", "hostname", "ip_address", "ipv6_address",
+		"mac_address", "family", "model", "software_version", "is_connected",
+	}
+
+	for _, key := range expectedKeys {
+		if _, ok := attrTypes[key]; !ok {
+			t.Errorf("AttrTypes missing key: %s", key)
+		}
+	}
+
+	if len(attrTypes) != len(expectedKeys) {
+		t.Errorf("AttrTypes has %d keys, expected %d", len(attrTypes), len(expectedKeys))
+	}
+}

--- a/internal/provider/config_setup/data_source_device.go
+++ b/internal/provider/config_setup/data_source_device.go
@@ -1,0 +1,101 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/paloaltonetworks/scm-go/generated/config_setup"
+	models "github.com/paloaltonetworks/terraform-provider-scm/internal/models/config_setup"
+	"github.com/paloaltonetworks/terraform-provider-scm/internal/utils"
+)
+
+// DATA SOURCE for SCM Device (Package: config_setup)
+var (
+	_ datasource.DataSource              = &DeviceDataSource{}
+	_ datasource.DataSourceWithConfigure = &DeviceDataSource{}
+)
+
+func NewDeviceDataSource() datasource.DataSource {
+	return &DeviceDataSource{}
+}
+
+// DeviceDataSource defines the data source implementation.
+type DeviceDataSource struct {
+	client *config_setup.APIClient
+}
+
+func (d *DeviceDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_device"
+}
+
+func (d *DeviceDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = models.DevicesDataSourceSchema
+}
+
+func (d *DeviceDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	clients, ok := req.ProviderData.(map[string]interface{})
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type", fmt.Sprintf("Expected map[string]interface{}, got: %T.", req.ProviderData))
+		return
+	}
+	client, ok := clients["config_setup"].(*config_setup.APIClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Client Type", "Expected *config_setup.APIClient for 'config_setup' client.")
+		return
+	}
+	d.client = client
+}
+
+func (d *DeviceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	tflog.Debug(ctx, "--- ENTER: DeviceDataSource.Read ---")
+
+	var data models.DevicesTf
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.Id.IsNull() {
+		resp.Diagnostics.AddError("Missing Identifier", "'id' must be provided for the Device data source.")
+		return
+	}
+
+	objectId := data.Id.ValueString()
+	tflog.Debug(ctx, "Reading Device data source by ID", map[string]interface{}{"id": objectId})
+
+	getReq := d.client.DevicesAPI.GetDeviceByID(ctx, objectId)
+	scmObject, httpRes, err := getReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Device", fmt.Sprintf("Could not read Device with ID %s: %s", objectId, err.Error()))
+		detailedMessage := utils.PrintScmError(err)
+		resp.Diagnostics.AddError("Resource Get Failed: API Request Failed", detailedMessage)
+		return
+	}
+	if httpRes.StatusCode != 200 {
+		resp.Diagnostics.AddError("Unexpected HTTP status code", fmt.Sprintf("Expected 200, got %d", httpRes.StatusCode))
+		return
+	}
+
+	// Pack the response into the Terraform model.
+	model, diags := packDevicesFromSdk(ctx, *scmObject)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create the composite Tfid.
+	var idBuilder strings.Builder
+	idBuilder.WriteString(":::")
+	idBuilder.WriteString(model.Id.ValueString())
+	model.Tfid = types.StringValue(idBuilder.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/config_setup/data_source_device_list.go
+++ b/internal/provider/config_setup/data_source_device_list.go
@@ -1,0 +1,127 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/paloaltonetworks/scm-go/generated/config_setup"
+	models "github.com/paloaltonetworks/terraform-provider-scm/internal/models/config_setup"
+	"github.com/paloaltonetworks/terraform-provider-scm/internal/utils"
+)
+
+var (
+	_ datasource.DataSource              = &DeviceListDataSource{}
+	_ datasource.DataSourceWithConfigure = &DeviceListDataSource{}
+)
+
+func NewDeviceListDataSource() datasource.DataSource {
+	return &DeviceListDataSource{}
+}
+
+// DeviceListDataSource defines the data source implementation.
+type DeviceListDataSource struct {
+	client *config_setup.APIClient
+}
+
+func (d *DeviceListDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_device_list"
+}
+
+func (d *DeviceListDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = models.DevicesListDataSourceSchema
+}
+
+func (d *DeviceListDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	clients, ok := req.ProviderData.(map[string]interface{})
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type", fmt.Sprintf("Expected map[string]interface{}, got: %T.", req.ProviderData))
+		return
+	}
+	client, ok := clients["config_setup"].(*config_setup.APIClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Client Type", "Expected *config_setup.APIClient for 'config_setup' client.")
+		return
+	}
+	d.client = client
+}
+
+func (d *DeviceListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data models.DevicesListModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create the API request.
+	listReq := d.client.DevicesAPI.ListDevices(ctx)
+
+	if !data.Limit.IsNull() {
+		tflog.Debug(ctx, "Applying filter", map[string]interface{}{"param": "limit", "value": data.Limit})
+		listReq = listReq.Limit(int32(data.Limit.ValueInt64()))
+	}
+	if !data.Offset.IsNull() {
+		tflog.Debug(ctx, "Applying filter", map[string]interface{}{"param": "offset", "value": data.Offset})
+		listReq = listReq.Offset(int32(data.Offset.ValueInt64()))
+	}
+	if !data.Folder.IsNull() {
+		tflog.Debug(ctx, "Applying filter", map[string]interface{}{"param": "folder", "value": data.Folder})
+		listReq = listReq.Folder(data.Folder.ValueString())
+	}
+
+	// Execute the request.
+	listResponse, _, err := listReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Devices", fmt.Sprintf("Could not list Devices: %s", err.Error()))
+		detailedMessage := utils.PrintScmError(err)
+		resp.Diagnostics.AddError("Resource Listing Failed: API Request Failed", detailedMessage)
+		return
+	}
+
+	if listResponse == nil || listResponse.GetData() == nil {
+		return
+	}
+
+	total := int64(listResponse.GetTotal())
+	data.Total = types.Int64PointerValue(&total)
+	data.Limit = types.Int64Value(int64(listResponse.GetLimit()))
+	data.Offset = types.Int64Value(int64(listResponse.GetOffset()))
+
+	// Pack the list response.
+	packedList, diags := packDevicesListFromSdk(ctx, listResponse.GetData())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(packedList.ElementsAs(ctx, &data.Data, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create a unique TFID for this data source.
+	var idBuilder strings.Builder
+	idBuilder.WriteString(":::")
+	if !data.Folder.IsNull() {
+		idBuilder.WriteString(data.Folder.ValueString())
+	}
+	idBuilder.WriteString(":")
+	if !data.Limit.IsNull() {
+		idBuilder.WriteString(strconv.FormatInt(data.Limit.ValueInt64(), 10))
+	}
+	idBuilder.WriteString(":")
+	if !data.Offset.IsNull() {
+		idBuilder.WriteString(strconv.FormatInt(data.Offset.ValueInt64(), 10))
+	}
+	data.Tfid = types.StringValue(idBuilder.String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/config_setup/datasources.go
+++ b/internal/provider/config_setup/datasources.go
@@ -7,6 +7,8 @@ import (
 // GetDataSources returns the list of data sources for this package.
 func GetDataSources() []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewDeviceDataSource,
+		NewDeviceListDataSource,
 		NewFolderDataSource,
 		NewLabelDataSource,
 		NewSnippetDataSource,

--- a/internal/provider/config_setup/resource_device.go
+++ b/internal/provider/config_setup/resource_device.go
@@ -1,0 +1,259 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/paloaltonetworks/scm-go/generated/config_setup"
+	models "github.com/paloaltonetworks/terraform-provider-scm/internal/models/config_setup"
+	"github.com/paloaltonetworks/terraform-provider-scm/internal/utils"
+)
+
+// RESOURCE for SCM Device (Package: config_setup)
+// This resource manages device-to-folder assignment, labels, snippets, description, and display_name.
+// The device itself is NOT created or deleted by Terraform — it already exists in SCM.
+var (
+	_ resource.Resource                = &DeviceResource{}
+	_ resource.ResourceWithConfigure   = &DeviceResource{}
+	_ resource.ResourceWithImportState = &DeviceResource{}
+)
+
+func NewDeviceResource() resource.Resource {
+	return &DeviceResource{}
+}
+
+// DeviceResource defines the resource implementation.
+type DeviceResource struct {
+	client *config_setup.APIClient
+}
+
+func (r *DeviceResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_device"
+}
+
+func (r *DeviceResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = models.DevicesResourceSchema
+}
+
+func (r *DeviceResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	clients, ok := req.ProviderData.(map[string]interface{})
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", fmt.Sprintf("Expected map[string]interface{}, got: %T.", req.ProviderData))
+		return
+	}
+	client, ok := clients["config_setup"].(*config_setup.APIClient)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Client Type", "Expected *config_setup.APIClient for 'config_setup' client.")
+		return
+	}
+	r.client = client
+}
+
+// Create adopts an existing device by setting the desired folder, labels, snippets, etc.
+// Since the device already exists in SCM, Create performs an Update to set the desired state.
+func (r *DeviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	tflog.Debug(ctx, "Starting Create function for Device")
+	var plan models.DevicesTf
+
+	// 1. Get the plan from Terraform.
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deviceId := plan.Id.ValueString()
+	tflog.Debug(ctx, "Adopting device into Terraform management", map[string]interface{}{"id": deviceId})
+
+	// 2. Unpack the plan into an SDK DevicesPut object.
+	sdkPut, diags := unpackDevicesToSdkPut(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 3. Update the device to set the desired folder/labels/snippets.
+	updateReq := r.client.DevicesAPI.UpdateDeviceByID(ctx, deviceId).DevicesPut(*sdkPut)
+	_, httpErr, err := updateReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating device during create", err.Error())
+		if httpErr != nil {
+			detailedMessage := utils.PrintScmError(err)
+			resp.Diagnostics.AddError("SCM Resource Creation Failed: API Request Failed", detailedMessage)
+		}
+		return
+	}
+
+	// 4. Read back the device to get the full state.
+	getReq := r.client.DevicesAPI.GetDeviceByID(ctx, deviceId)
+	scmObject, _, err := getReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading device after create", err.Error())
+		detailedMessage := utils.PrintScmError(err)
+		resp.Diagnostics.AddError("SCM Resource Read Failed: API Request Failed", detailedMessage)
+		return
+	}
+
+	// 5. Pack the response into the Terraform model.
+	model, diags := packDevicesFromSdk(ctx, *scmObject)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 6. Set the Terraform ID.
+	var idBuilder strings.Builder
+	idBuilder.WriteString(":::")
+	idBuilder.WriteString(model.Id.ValueString())
+	model.Tfid = types.StringValue(idBuilder.String())
+
+	tflog.Debug(ctx, "Created (adopted) device", map[string]interface{}{"tfid": model.Tfid.ValueString()})
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	tflog.Debug(ctx, "Starting Read function for Device")
+	var savestate models.DevicesTf
+
+	// 1. Fetch the state.
+	resp.Diagnostics.Append(req.State.Get(ctx, &savestate)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tokens := strings.Split(savestate.Tfid.ValueString(), ":")
+	if len(tokens) != 4 {
+		resp.Diagnostics.AddError("Error parsing TFID", fmt.Sprintf("Expected a TFID with 4 parts separated by ':', but got %d parts for TFID %s", len(tokens), savestate.Tfid.ValueString()))
+		return
+	}
+	objectId := tokens[3]
+
+	// 2. Read the device from the API.
+	tflog.Debug(ctx, "Reading device from SCM API", map[string]interface{}{"id": objectId})
+	getReq := r.client.DevicesAPI.GetDeviceByID(ctx, objectId)
+	scmObject, httpErr, err := getReq.Execute()
+	if err != nil {
+		if httpErr != nil && httpErr.StatusCode == http.StatusNotFound {
+			tflog.Debug(ctx, "Device not found on read. Removing from state.", map[string]interface{}{"id": objectId})
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Error reading device", err.Error())
+			detailedMessage := utils.PrintScmError(err)
+			resp.Diagnostics.AddError("SCM Resource Read Failed: API Request Failed", detailedMessage)
+		}
+		return
+	}
+
+	// 3. Pack the response.
+	model, diags := packDevicesFromSdk(ctx, *scmObject)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 4. Carry over the TFID from existing state.
+	model.Tfid = savestate.Tfid
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	tflog.Debug(ctx, "Starting Update function for Device")
+	var plan models.DevicesTf
+	var state models.DevicesTf
+
+	// 1. Get plan and state.
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 2. Unpack the plan into DevicesPut.
+	sdkPut, diags := unpackDevicesToSdkPut(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 3. Get the ID from the TFID.
+	tokens := strings.Split(state.Tfid.ValueString(), ":")
+	if len(tokens) != 4 {
+		resp.Diagnostics.AddError("Error parsing TFID", fmt.Sprintf("Expected a TFID with 4 parts separated by ':', but got %d parts for TFID %s", len(tokens), state.Tfid.ValueString()))
+		return
+	}
+	objectId := tokens[3]
+
+	// 4. Make the update call.
+	tflog.Debug(ctx, "Updating device on SCM API", map[string]interface{}{"id": objectId})
+	updateReq := r.client.DevicesAPI.UpdateDeviceByID(ctx, objectId).DevicesPut(*sdkPut)
+	_, httpErr, err := updateReq.Execute()
+	if err != nil {
+		if httpErr != nil && httpErr.StatusCode == http.StatusNotFound {
+			tflog.Debug(ctx, "Device not found on update. Removing from state.", map[string]interface{}{"id": objectId})
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Error updating device", err.Error())
+			detailedMessage := utils.PrintScmError(err)
+			resp.Diagnostics.AddError("SCM Resource Update Failed: API Request Failed", detailedMessage)
+		}
+		return
+	}
+
+	// 5. Read back the device to get the full state after update.
+	getReq := r.client.DevicesAPI.GetDeviceByID(ctx, objectId)
+	scmObject, _, err := getReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading device after update", err.Error())
+		detailedMessage := utils.PrintScmError(err)
+		resp.Diagnostics.AddError("SCM Resource Read Failed: API Request Failed", detailedMessage)
+		return
+	}
+
+	// 6. Pack the response.
+	model, diags := packDevicesFromSdk(ctx, *scmObject)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 7. Preserve the ID from the plan and TFID from state.
+	_ = req.Plan.GetAttribute(ctx, path.Root("id"), &model.Id)
+	model.Tfid = state.Tfid
+
+	tflog.Debug(ctx, "Updated device", map[string]interface{}{"tfid": model.Tfid.ValueString()})
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+// Delete removes the device from Terraform state only.
+// The physical device is NOT deleted from SCM — it was onboarded externally.
+func (r *DeviceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Debug(ctx, "Starting Delete function for Device")
+	var data models.DevicesTf
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Removing device from Terraform state. The device remains in SCM.", map[string]interface{}{
+		"id":   data.Id.ValueString(),
+		"name": data.Name.ValueString(),
+	})
+	// No API call — just allow Terraform to remove the resource from state.
+}
+
+func (r *DeviceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("tfid"), req, resp)
+}

--- a/internal/provider/config_setup/resource_device_mappers.go
+++ b/internal/provider/config_setup/resource_device_mappers.go
@@ -1,0 +1,174 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/paloaltonetworks/scm-go/generated/config_setup"
+	models "github.com/paloaltonetworks/terraform-provider-scm/internal/models/config_setup"
+)
+
+// unpackDevicesToSdkPut converts the Terraform model into the SDK DevicesPut struct for update operations.
+func unpackDevicesToSdkPut(ctx context.Context, model *models.DevicesTf) (*config_setup.DevicesPut, diag.Diagnostics) {
+	tflog.Debug(ctx, "Entering unpack helper for DevicesPut")
+	diags := diag.Diagnostics{}
+
+	var sdk config_setup.DevicesPut
+
+	if !model.Folder.IsNull() && !model.Folder.IsUnknown() {
+		sdk.Folder = model.Folder.ValueStringPointer()
+		tflog.Debug(ctx, "Unpacked primitive pointer", map[string]interface{}{"field": "Folder", "value": *sdk.Folder})
+	}
+
+	if !model.Description.IsNull() && !model.Description.IsUnknown() {
+		sdk.Description = model.Description.ValueStringPointer()
+		tflog.Debug(ctx, "Unpacked primitive pointer", map[string]interface{}{"field": "Description", "value": *sdk.Description})
+	}
+
+	if !model.DisplayName.IsNull() && !model.DisplayName.IsUnknown() {
+		sdk.DisplayName = model.DisplayName.ValueStringPointer()
+		tflog.Debug(ctx, "Unpacked primitive pointer", map[string]interface{}{"field": "DisplayName", "value": *sdk.DisplayName})
+	}
+
+	if !model.Labels.IsNull() && !model.Labels.IsUnknown() {
+		tflog.Debug(ctx, "Unpacking list of primitives for field Labels")
+		diags.Append(model.Labels.ElementsAs(ctx, &sdk.Labels, false)...)
+	}
+
+	if !model.Snippets.IsNull() && !model.Snippets.IsUnknown() {
+		tflog.Debug(ctx, "Unpacking list of primitives for field Snippets")
+		diags.Append(model.Snippets.ElementsAs(ctx, &sdk.Snippets, false)...)
+	}
+
+	tflog.Debug(ctx, "Exiting unpack helper for DevicesPut", map[string]interface{}{"has_errors": diags.HasError()})
+	return &sdk, diags
+}
+
+// packDevicesFromSdk converts the SDK Devices struct into the Terraform model.
+func packDevicesFromSdk(ctx context.Context, sdk config_setup.Devices) (*models.DevicesTf, diag.Diagnostics) {
+	tflog.Debug(ctx, "Entering pack helper for Devices", map[string]interface{}{"id": sdk.Id})
+	diags := diag.Diagnostics{}
+	var model models.DevicesTf
+
+	// Required fields
+	model.Id = basetypes.NewStringValue(sdk.Id)
+	model.Name = basetypes.NewStringValue(sdk.Name)
+	model.Folder = basetypes.NewStringValue(sdk.Folder)
+
+	// Optional string pointer fields
+	if sdk.Description != nil {
+		model.Description = basetypes.NewStringValue(*sdk.Description)
+	} else {
+		model.Description = basetypes.NewStringNull()
+	}
+
+	if sdk.DisplayName != nil {
+		model.DisplayName = basetypes.NewStringValue(*sdk.DisplayName)
+	} else {
+		model.DisplayName = basetypes.NewStringNull()
+	}
+
+	if sdk.Hostname != nil {
+		model.Hostname = basetypes.NewStringValue(*sdk.Hostname)
+	} else {
+		model.Hostname = basetypes.NewStringNull()
+	}
+
+	if sdk.IpAddress != nil {
+		model.IpAddress = basetypes.NewStringValue(*sdk.IpAddress)
+	} else {
+		model.IpAddress = basetypes.NewStringNull()
+	}
+
+	if sdk.IpV6Address != nil {
+		model.IpV6Address = basetypes.NewStringValue(*sdk.IpV6Address)
+	} else {
+		model.IpV6Address = basetypes.NewStringNull()
+	}
+
+	if sdk.MacAddress != nil {
+		model.MacAddress = basetypes.NewStringValue(*sdk.MacAddress)
+	} else {
+		model.MacAddress = basetypes.NewStringNull()
+	}
+
+	if sdk.Family != nil {
+		model.Family = basetypes.NewStringValue(*sdk.Family)
+	} else {
+		model.Family = basetypes.NewStringNull()
+	}
+
+	if sdk.Model != nil {
+		model.Model = basetypes.NewStringValue(*sdk.Model)
+	} else {
+		model.Model = basetypes.NewStringNull()
+	}
+
+	if sdk.SoftwareVersion != nil {
+		model.SoftwareVersion = basetypes.NewStringValue(*sdk.SoftwareVersion)
+	} else {
+		model.SoftwareVersion = basetypes.NewStringNull()
+	}
+
+	if sdk.IsConnected != nil {
+		model.IsConnected = basetypes.NewBoolValue(*sdk.IsConnected)
+	} else {
+		model.IsConnected = basetypes.NewBoolNull()
+	}
+
+	// List fields
+	var elemType attr.Type = basetypes.StringType{}
+	if sdk.Labels != nil {
+		var d diag.Diagnostics
+		model.Labels, d = basetypes.NewListValueFrom(ctx, elemType, sdk.Labels)
+		diags.Append(d...)
+	} else {
+		model.Labels = basetypes.NewListNull(elemType)
+	}
+
+	if sdk.Snippets != nil {
+		var d diag.Diagnostics
+		model.Snippets, d = basetypes.NewListValueFrom(ctx, elemType, sdk.Snippets)
+		diags.Append(d...)
+	} else {
+		model.Snippets = basetypes.NewListNull(elemType)
+	}
+
+	tflog.Debug(ctx, "Exiting pack helper for Devices", map[string]interface{}{"has_errors": diags.HasError()})
+	return &model, diags
+}
+
+// packDevicesFromSdkToObject converts the SDK Devices struct into a Terraform object value.
+func packDevicesFromSdkToObject(ctx context.Context, sdk config_setup.Devices) (types.Object, diag.Diagnostics) {
+	model, diags := packDevicesFromSdk(ctx, sdk)
+	if diags.HasError() {
+		return basetypes.NewObjectNull(models.DevicesTf{}.AttrTypes()), diags
+	}
+	obj, d := types.ObjectValueFrom(ctx, models.DevicesTf{}.AttrTypes(), model)
+	diags.Append(d...)
+	return obj, diags
+}
+
+// packDevicesListFromSdk converts a list of SDK Devices structs into a Terraform list.
+func packDevicesListFromSdk(ctx context.Context, sdks []config_setup.Devices) (types.List, diag.Diagnostics) {
+	tflog.Debug(ctx, "Entering list pack helper for Devices")
+	diags := diag.Diagnostics{}
+	var data []models.DevicesTf
+
+	for i, sdk := range sdks {
+		tflog.Debug(ctx, "Packing item to list", map[string]interface{}{"index": i})
+		model, d := packDevicesFromSdk(ctx, sdk)
+		diags.Append(d...)
+		if diags.HasError() {
+			return basetypes.NewListNull(models.DevicesTf{}.AttrType()), diags
+		}
+		data = append(data, *model)
+	}
+	tflog.Debug(ctx, "Exiting list pack helper for Devices", map[string]interface{}{"has_errors": diags.HasError()})
+	return basetypes.NewListValueFrom(ctx, models.DevicesTf{}.AttrType(), data)
+}

--- a/internal/provider/config_setup/resource_device_mappers_test.go
+++ b/internal/provider/config_setup/resource_device_mappers_test.go
@@ -1,0 +1,366 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/paloaltonetworks/scm-go/generated/config_setup"
+	models "github.com/paloaltonetworks/terraform-provider-scm/internal/models/config_setup"
+)
+
+// --- Tests for packDevicesFromSdk ---
+
+func Test_packDevicesFromSdk_AllFields(t *testing.T) {
+	ctx := context.Background()
+
+	sdk := config_setup.Devices{
+		Id:              "test-uuid-1234",
+		Name:            "00112233445566",
+		Folder:          "Production",
+		Description:     strPtr("Test firewall"),
+		DisplayName:     strPtr("fw-prod-001"),
+		Hostname:        strPtr("fw-prod-001.example.com"),
+		IpAddress:       strPtr("10.0.0.1"),
+		IpV6Address:     strPtr("fd00::1"),
+		MacAddress:      strPtr("aa:bb:cc:dd:ee:ff"),
+		Family:          strPtr("vm"),
+		Model:           strPtr("PA-VM"),
+		SoftwareVersion: strPtr("11.1.0"),
+		IsConnected:     boolPtr(true),
+		Labels:          []string{"production", "azure"},
+		Snippets:        []string{"snippet-1", "snippet-2"},
+	}
+
+	model, diags := packDevicesFromSdk(ctx, sdk)
+	if diags.HasError() {
+		t.Fatalf("packDevicesFromSdk returned errors: %v", diags.Errors())
+	}
+
+	// Required fields
+	assertEqual(t, "Id", "test-uuid-1234", model.Id.ValueString())
+	assertEqual(t, "Name", "00112233445566", model.Name.ValueString())
+	assertEqual(t, "Folder", "Production", model.Folder.ValueString())
+
+	// Optional string pointer fields
+	assertStringPtrEqual(t, "Description", "Test firewall", model.Description)
+	assertStringPtrEqual(t, "DisplayName", "fw-prod-001", model.DisplayName)
+	assertStringPtrEqual(t, "Hostname", "fw-prod-001.example.com", model.Hostname)
+	assertStringPtrEqual(t, "IpAddress", "10.0.0.1", model.IpAddress)
+	assertStringPtrEqual(t, "IpV6Address", "fd00::1", model.IpV6Address)
+	assertStringPtrEqual(t, "MacAddress", "aa:bb:cc:dd:ee:ff", model.MacAddress)
+	assertStringPtrEqual(t, "Family", "vm", model.Family)
+	assertStringPtrEqual(t, "Model", "PA-VM", model.Model)
+	assertStringPtrEqual(t, "SoftwareVersion", "11.1.0", model.SoftwareVersion)
+
+	// Bool field
+	if model.IsConnected.IsNull() || model.IsConnected.IsUnknown() {
+		t.Errorf("IsConnected should not be null/unknown")
+	}
+	if model.IsConnected.ValueBool() != true {
+		t.Errorf("IsConnected: expected true, got false")
+	}
+
+	// List fields
+	if model.Labels.IsNull() {
+		t.Errorf("Labels should not be null")
+	}
+	if len(model.Labels.Elements()) != 2 {
+		t.Errorf("Labels: expected 2 elements, got %d", len(model.Labels.Elements()))
+	}
+	if model.Snippets.IsNull() {
+		t.Errorf("Snippets should not be null")
+	}
+	if len(model.Snippets.Elements()) != 2 {
+		t.Errorf("Snippets: expected 2 elements, got %d", len(model.Snippets.Elements()))
+	}
+}
+
+func Test_packDevicesFromSdk_NilOptionalFields(t *testing.T) {
+	ctx := context.Background()
+
+	// Only required fields set, everything else nil
+	sdk := config_setup.Devices{
+		Id:     "test-uuid-5678",
+		Name:   "99887766554433",
+		Folder: "All Firewalls",
+	}
+
+	model, diags := packDevicesFromSdk(ctx, sdk)
+	if diags.HasError() {
+		t.Fatalf("packDevicesFromSdk returned errors: %v", diags.Errors())
+	}
+
+	// Required fields should be populated
+	assertEqual(t, "Id", "test-uuid-5678", model.Id.ValueString())
+	assertEqual(t, "Name", "99887766554433", model.Name.ValueString())
+	assertEqual(t, "Folder", "All Firewalls", model.Folder.ValueString())
+
+	// Optional fields should be null
+	assertNull(t, "Description", model.Description)
+	assertNull(t, "DisplayName", model.DisplayName)
+	assertNull(t, "Hostname", model.Hostname)
+	assertNull(t, "IpAddress", model.IpAddress)
+	assertNull(t, "IpV6Address", model.IpV6Address)
+	assertNull(t, "MacAddress", model.MacAddress)
+	assertNull(t, "Family", model.Family)
+	assertNull(t, "Model", model.Model)
+	assertNull(t, "SoftwareVersion", model.SoftwareVersion)
+	assertNull(t, "IsConnected (bool)", model.IsConnected)
+
+	// Lists should be null when nil
+	if !model.Labels.IsNull() {
+		t.Errorf("Labels should be null when SDK value is nil")
+	}
+	if !model.Snippets.IsNull() {
+		t.Errorf("Snippets should be null when SDK value is nil")
+	}
+}
+
+func Test_packDevicesFromSdk_EmptyLists(t *testing.T) {
+	ctx := context.Background()
+
+	sdk := config_setup.Devices{
+		Id:       "test-uuid-9999",
+		Name:     "emptylistdevice",
+		Folder:   "TestFolder",
+		Labels:   []string{},
+		Snippets: []string{},
+	}
+
+	model, diags := packDevicesFromSdk(ctx, sdk)
+	if diags.HasError() {
+		t.Fatalf("packDevicesFromSdk returned errors: %v", diags.Errors())
+	}
+
+	// Empty lists (non-nil) should produce empty TF lists, not null
+	if model.Labels.IsNull() {
+		t.Errorf("Labels should not be null for an empty (non-nil) slice")
+	}
+	if len(model.Labels.Elements()) != 0 {
+		t.Errorf("Labels: expected 0 elements, got %d", len(model.Labels.Elements()))
+	}
+	if model.Snippets.IsNull() {
+		t.Errorf("Snippets should not be null for an empty (non-nil) slice")
+	}
+	if len(model.Snippets.Elements()) != 0 {
+		t.Errorf("Snippets: expected 0 elements, got %d", len(model.Snippets.Elements()))
+	}
+}
+
+// --- Tests for unpackDevicesToSdkPut ---
+
+func Test_unpackDevicesToSdkPut_AllFields(t *testing.T) {
+	ctx := context.Background()
+
+	labels, _ := basetypes.NewListValueFrom(ctx, basetypes.StringType{}, []string{"label1", "label2"})
+	snippets, _ := basetypes.NewListValueFrom(ctx, basetypes.StringType{}, []string{"snip1"})
+
+	model := &devicesTfForTest{
+		Folder:      basetypes.NewStringValue("Azure Firewalls/Production"),
+		Description: basetypes.NewStringValue("Moved to production"),
+		DisplayName: basetypes.NewStringValue("fw-prod-001"),
+		Labels:      labels,
+		Snippets:    snippets,
+	}
+
+	sdkPut, diags := unpackDevicesToSdkPut(ctx, model.toDevicesTf())
+	if diags.HasError() {
+		t.Fatalf("unpackDevicesToSdkPut returned errors: %v", diags.Errors())
+	}
+
+	if sdkPut.Folder == nil || *sdkPut.Folder != "Azure Firewalls/Production" {
+		t.Errorf("Folder: expected 'Azure Firewalls/Production', got %v", sdkPut.Folder)
+	}
+	if sdkPut.Description == nil || *sdkPut.Description != "Moved to production" {
+		t.Errorf("Description: expected 'Moved to production', got %v", sdkPut.Description)
+	}
+	if sdkPut.DisplayName == nil || *sdkPut.DisplayName != "fw-prod-001" {
+		t.Errorf("DisplayName: expected 'fw-prod-001', got %v", sdkPut.DisplayName)
+	}
+	if len(sdkPut.Labels) != 2 {
+		t.Errorf("Labels: expected 2 elements, got %d", len(sdkPut.Labels))
+	}
+	if len(sdkPut.Snippets) != 1 {
+		t.Errorf("Snippets: expected 1 element, got %d", len(sdkPut.Snippets))
+	}
+}
+
+func Test_unpackDevicesToSdkPut_NullOptionalFields(t *testing.T) {
+	ctx := context.Background()
+
+	model := &devicesTfForTest{
+		Folder:      basetypes.NewStringValue("SomeFolder"),
+		Description: basetypes.NewStringNull(),
+		DisplayName: basetypes.NewStringNull(),
+		Labels:      basetypes.NewListNull(basetypes.StringType{}),
+		Snippets:    basetypes.NewListNull(basetypes.StringType{}),
+	}
+
+	sdkPut, diags := unpackDevicesToSdkPut(ctx, model.toDevicesTf())
+	if diags.HasError() {
+		t.Fatalf("unpackDevicesToSdkPut returned errors: %v", diags.Errors())
+	}
+
+	if sdkPut.Folder == nil || *sdkPut.Folder != "SomeFolder" {
+		t.Errorf("Folder: expected 'SomeFolder', got %v", sdkPut.Folder)
+	}
+	if sdkPut.Description != nil {
+		t.Errorf("Description: expected nil, got %v", sdkPut.Description)
+	}
+	if sdkPut.DisplayName != nil {
+		t.Errorf("DisplayName: expected nil, got %v", sdkPut.DisplayName)
+	}
+	if sdkPut.Labels != nil {
+		t.Errorf("Labels: expected nil, got %v", sdkPut.Labels)
+	}
+	if sdkPut.Snippets != nil {
+		t.Errorf("Snippets: expected nil, got %v", sdkPut.Snippets)
+	}
+}
+
+// --- Tests for packDevicesListFromSdk ---
+
+func Test_packDevicesListFromSdk_MultipleDevices(t *testing.T) {
+	ctx := context.Background()
+
+	sdks := []config_setup.Devices{
+		{Id: "id-1", Name: "serial-1", Folder: "Folder-A", Description: strPtr("desc-1")},
+		{Id: "id-2", Name: "serial-2", Folder: "Folder-B"},
+		{Id: "id-3", Name: "serial-3", Folder: "Folder-A", IsConnected: boolPtr(false)},
+	}
+
+	tfList, diags := packDevicesListFromSdk(ctx, sdks)
+	if diags.HasError() {
+		t.Fatalf("packDevicesListFromSdk returned errors: %v", diags.Errors())
+	}
+
+	if tfList.IsNull() {
+		t.Fatal("Expected a non-null list")
+	}
+	if len(tfList.Elements()) != 3 {
+		t.Errorf("Expected 3 elements in list, got %d", len(tfList.Elements()))
+	}
+}
+
+func Test_packDevicesListFromSdk_EmptyList(t *testing.T) {
+	ctx := context.Background()
+
+	tfList, diags := packDevicesListFromSdk(ctx, []config_setup.Devices{})
+	if diags.HasError() {
+		t.Fatalf("packDevicesListFromSdk returned errors: %v", diags.Errors())
+	}
+
+	// An empty slice produces a list with 0 elements (may be null depending on
+	// how NewListValueFrom handles a nil internal slice — both are acceptable).
+	if !tfList.IsNull() && len(tfList.Elements()) != 0 {
+		t.Errorf("Expected 0 elements or null list, got %d elements", len(tfList.Elements()))
+	}
+}
+
+// --- Tests for round-trip pack/unpack ---
+
+func Test_RoundTrip_PackThenUnpack(t *testing.T) {
+	ctx := context.Background()
+
+	// Start with SDK Devices (as returned from API read)
+	original := config_setup.Devices{
+		Id:          "round-trip-id",
+		Name:        "round-trip-serial",
+		Folder:      "TestFolder/SubFolder",
+		Description: strPtr("round trip test"),
+		DisplayName: strPtr("Round Trip FW"),
+		Labels:      []string{"env:test"},
+		Snippets:    []string{"s1", "s2"},
+	}
+
+	// Pack to TF model
+	model, diags := packDevicesFromSdk(ctx, original)
+	if diags.HasError() {
+		t.Fatalf("packDevicesFromSdk returned errors: %v", diags.Errors())
+	}
+
+	// Unpack back to SDK DevicesPut (the mutable fields)
+	sdkPut, diags := unpackDevicesToSdkPut(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("unpackDevicesToSdkPut returned errors: %v", diags.Errors())
+	}
+
+	// Verify the mutable fields survived the round trip
+	if *sdkPut.Folder != "TestFolder/SubFolder" {
+		t.Errorf("Folder round-trip failed: expected 'TestFolder/SubFolder', got '%s'", *sdkPut.Folder)
+	}
+	if *sdkPut.Description != "round trip test" {
+		t.Errorf("Description round-trip failed: expected 'round trip test', got '%s'", *sdkPut.Description)
+	}
+	if *sdkPut.DisplayName != "Round Trip FW" {
+		t.Errorf("DisplayName round-trip failed: expected 'Round Trip FW', got '%s'", *sdkPut.DisplayName)
+	}
+	if len(sdkPut.Labels) != 1 || sdkPut.Labels[0] != "env:test" {
+		t.Errorf("Labels round-trip failed: expected [env:test], got %v", sdkPut.Labels)
+	}
+	if len(sdkPut.Snippets) != 2 || sdkPut.Snippets[0] != "s1" || sdkPut.Snippets[1] != "s2" {
+		t.Errorf("Snippets round-trip failed: expected [s1, s2], got %v", sdkPut.Snippets)
+	}
+}
+
+// --- Test helpers ---
+
+// devicesTfForTest is a helper to build DevicesTf instances for testing
+// without needing to set all the computed fields
+type devicesTfForTest struct {
+	Folder      basetypes.StringValue
+	Description basetypes.StringValue
+	DisplayName basetypes.StringValue
+	Labels      basetypes.ListValue
+	Snippets    basetypes.ListValue
+}
+
+func (d *devicesTfForTest) toDevicesTf() *models.DevicesTf {
+	return &models.DevicesTf{
+		Id:          basetypes.NewStringValue("test-id"),
+		Name:        basetypes.NewStringNull(),
+		Folder:      d.Folder,
+		Description: d.Description,
+		DisplayName: d.DisplayName,
+		Labels:      d.Labels,
+		Snippets:    d.Snippets,
+		Hostname:    basetypes.NewStringNull(),
+		IpAddress:   basetypes.NewStringNull(),
+		IpV6Address: basetypes.NewStringNull(),
+		MacAddress:  basetypes.NewStringNull(),
+		Family:      basetypes.NewStringNull(),
+		Model:       basetypes.NewStringNull(),
+		SoftwareVersion: basetypes.NewStringNull(),
+		IsConnected: basetypes.NewBoolNull(),
+	}
+}
+
+func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }
+
+func assertEqual(t *testing.T, field, expected, actual string) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("%s: expected %q, got %q", field, expected, actual)
+	}
+}
+
+func assertStringPtrEqual(t *testing.T, field, expected string, actual basetypes.StringValue) {
+	t.Helper()
+	if actual.IsNull() || actual.IsUnknown() {
+		t.Errorf("%s: expected %q, got null/unknown", field, expected)
+		return
+	}
+	if actual.ValueString() != expected {
+		t.Errorf("%s: expected %q, got %q", field, expected, actual.ValueString())
+	}
+}
+
+func assertNull(t *testing.T, field string, actual interface{ IsNull() bool }) {
+	t.Helper()
+	if !actual.IsNull() {
+		t.Errorf("%s: expected null, got non-null", field)
+	}
+}

--- a/internal/provider/config_setup/resources.go
+++ b/internal/provider/config_setup/resources.go
@@ -7,6 +7,7 @@ import (
 // GetResources returns all resources for the config_setup package
 func GetResources() []func() resource.Resource {
 	return []func() resource.Resource{
+		NewDeviceResource,
 		NewFolderResource,
 		NewLabelResource,
 		NewSnippetResource,


### PR DESCRIPTION
## feat: Add `scm_device` resource and data sources for device-to-folder management

### Problem

Azure vWAN-connected firewalls onboarded into Strata Cloud Manager appear under "All Firewalls" but cannot be moved into the correct folder hierarchy (e.g. "Azure Firewalls > Production Services") via Terraform. The SCM API supports device-to-folder assignment through its Devices PUT endpoint, and the SDK already had the `Devices` and `DevicesPut` model structs generated from the OpenAPI spec, but no API service was wired up — and the Terraform provider had no corresponding resource or data source.

### Solution

**New resource: `scm_device`** — an adopt-and-manage resource that allows Terraform to manage an existing device's folder assignment, labels, snippets, description, and display name.

- **Create** adopts an existing device by updating it to the desired folder/labels/snippets (the device already exists in SCM — it was onboarded externally).
- **Read** retrieves the full device state from the API.
- **Update** changes the mutable fields (folder, description, display_name, labels, snippets) via the Devices PUT endpoint.
- **Delete** removes the device from Terraform state only — the physical device is NOT deleted from SCM.
- **Import** supported via device UUID.

**New data sources:**
- `scm_device` — look up a single device by UUID.
- `scm_device_list` — list devices with optional folder filter, limit, and offset.

### Usage Example

```hcl
# Move a firewall into the correct folder
resource "scm_device" "fw_prod" {
  id     = "device-uuid-here"
  folder = "Azure Firewalls/Production Services"
  labels = ["production", "vwan"]
}

# Look up a device
data "scm_device" "lookup" {
  id = "device-uuid-here"
}

# List all devices in a folder
data "scm_device_list" "prod_firewalls" {
  folder = "Azure Firewalls/Production Services"
}
```

### Changes

**Modified files:**
- `go.mod` — added local replace directive for scm-go development (to be updated to module version before merge)
- `internal/provider/config_setup/resources.go` — registered `NewDeviceResource`
- `internal/provider/config_setup/datasources.go` — registered `NewDeviceDataSource` and `NewDeviceListDataSource`

**New files:**
- `internal/models/config_setup/model_devices.go` — Terraform schema model with resource, data source, and list data source schemas
- `internal/models/config_setup/model_devices_test.go` — schema validation tests (7 tests)
- `internal/provider/config_setup/resource_device.go` — `scm_device` resource implementation
- `internal/provider/config_setup/resource_device_mappers.go` — pack/unpack functions between TF model and SDK structs
- `internal/provider/config_setup/resource_device_mappers_test.go` — mapper unit tests (8 tests)
- `internal/provider/config_setup/data_source_device.go` — `scm_device` data source
- `internal/provider/config_setup/data_source_device_list.go` — `scm_device_list` data source

### Companion PR

> **Depends on [PaloAltoNetworks/scm-go#20](https://github.com/PaloAltoNetworks/scm-go/pull/20)** — must be merged and tagged before this PR can be finalized.

This PR depends on a corresponding change in the scm-go SDK ([PaloAltoNetworks/scm-go#20](https://github.com/PaloAltoNetworks/scm-go/pull/20)) that adds the `DevicesAPIService` with `ListDevices`, `GetDeviceByID`, and `UpdateDeviceByID` methods. The `go.mod` replace directive should be updated to point to the published scm-go version once that SDK PR is merged and tagged.

### Testing

- 15 unit tests pass (7 schema + 8 mapper tests)
- All tests run via `go test ./internal/... -v`
- SDK integration tests (in scm-go repo) cover the API endpoints against live SCM
- Full `go build ./...` compiles clean
